### PR TITLE
Estimated maximum augmentation strategy

### DIFF
--- a/maxsmi/tests/test_utils_data.py
+++ b/maxsmi/tests/test_utils_data.py
@@ -6,7 +6,7 @@ Unit and regression test for the maxsmi package.
 # import maxsmi
 import pytest
 import sys
-from maxsmi.utils_data import data_retrieval
+from maxsmi.utils_data import data_retrieval, process_ESOL
 
 
 def test_maxsmi_imported():
@@ -22,8 +22,20 @@ def test_maxsmi_imported():
         ("lipophilicity", "Cn1c(CN2CCN(CC2)c3ccc(Cl)cc3)nc4ccccc14"),
         ("dncn", "OCC3OC(OCC2OC(OC(C#N)c1ccccc1)C(O)C(O)C2O)C(O)C(O)C3O "),
         ("free_solv", "CN(C)C(=O)c1ccc(cc1)OC"),
+        ("ESOL_small", "Cc1occc1C(=O)Nc2ccccc2"),
     ],
 )
 def test_data_retrieval(task, solution):
     dataframe = data_retrieval(task)
     assert solution == dataframe.smiles[0]
+
+
+@pytest.mark.parametrize(
+    "num_heavy_atoms, solution",
+    [
+        (25, 15),
+    ],
+)
+def test_process_ESOL(num_heavy_atoms, solution):
+    dataframe = process_ESOL(num_heavy_atoms)
+    assert solution == dataframe.loc[0, "num_heavy_atom"]

--- a/maxsmi/tests/test_utils_smiles.py
+++ b/maxsmi/tests/test_utils_smiles.py
@@ -15,6 +15,7 @@ from maxsmi.utils_smiles import (
     smiles_to_selfies,
     smiles_to_deepsmiles,
     control_smiles_duplication,
+    get_num_heavy_atoms,
 )
 
 
@@ -100,3 +101,12 @@ def test_smiles_to_selfies(smiles, solution):
 def test_smiles_to_deepsmiles(smiles, solution):
     deepsmiles = smiles_to_deepsmiles(smiles)
     assert solution == deepsmiles
+
+
+@pytest.mark.parametrize(
+    "smiles, solution",
+    [("C", 1), ("OC", 2), ("KCahsbl", None)],
+)
+def test_get_num_heavy_atoms(smiles, solution):
+    num_heavy_atoms = get_num_heavy_atoms(smiles)
+    assert solution == num_heavy_atoms

--- a/maxsmi/utils_data.py
+++ b/maxsmi/utils_data.py
@@ -6,7 +6,9 @@ http://moleculenet.ai/
 Handles the primary functions
 """
 
+import logging
 import pandas as pd
+from maxsmi.utils_smiles import get_num_heavy_atoms
 
 
 def data_retrieval(target_data="ESOL"):
@@ -38,10 +40,13 @@ def data_retrieval(target_data="ESOL"):
         data = pd.read_csv(url)
         task = "exp"
 
+    elif target_data == "ESOL_small":
+        data = process_ESOL()
+        task = "measured log solubility in mols per litre"
+
     else:
         if target_data != "ESOL":
-            # TODO: use warnings
-            print("Invalid data. Choosing ESOL by default. ")
+            logging.warning("Invalid data. Choosing ESOL by default.")
         url = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/delaney-processed.csv"
         data = pd.read_csv(url)
         task = "measured log solubility in mols per litre"
@@ -50,3 +55,27 @@ def data_retrieval(target_data="ESOL"):
     dataframe = dataframe.rename(columns={task: "target"})
 
     return dataframe
+
+
+def process_ESOL(num_heavy_atoms=25):
+    """
+    Considers ony a subset of the ESOL data, where molecule with up to `num_heavy_atoms` heavy atoms are retained.
+
+    Parameters
+    ----------
+    num_heavy_atoms : int
+        The molecules with `num_heavy_atoms` to keep.
+
+    Return
+    ------
+    dataframe: pd.Pandas
+        Pandas data frame with small molecules only.
+
+    """
+    url = (
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/delaney-processed.csv"
+    )
+    data = pd.read_csv(url)
+    data["num_heavy_atom"] = data["smiles"].apply(get_num_heavy_atoms)
+
+    return data[data["num_heavy_atom"] <= num_heavy_atoms]

--- a/maxsmi/utils_data.py
+++ b/maxsmi/utils_data.py
@@ -77,5 +77,6 @@ def process_ESOL(num_heavy_atoms=25):
     )
     data = pd.read_csv(url)
     data["num_heavy_atom"] = data["smiles"].apply(get_num_heavy_atoms)
+    data = data.loc[data["num_heavy_atom"] <= num_heavy_atoms]
 
-    return data[data["num_heavy_atom"] <= num_heavy_atoms]
+    return data.reset_index(drop=True)

--- a/maxsmi/utils_smiles.py
+++ b/maxsmi/utils_smiles.py
@@ -193,3 +193,26 @@ def smiles_to_deepsmiles(smiles):
     """
     converter = deepsmiles.Converter(rings=True, branches=True)
     return [converter.encode(smiles)]
+
+
+def get_num_heavy_atoms(smiles):
+    """
+    Takes a SMILES and return the number of heavy atoms of the molecule.
+
+    Parameters
+    ----------
+    smiles : str
+        SMILES string describing a compound.
+
+    Returns
+    -------
+    int
+        The number of heavy atoms of the molecule.
+    """
+
+    mol = Chem.MolFromSmiles(smiles)
+
+    if mol is None:
+        return None
+    else:
+        return mol.GetNumHeavyAtoms()


### PR DESCRIPTION
## Description
The augmentation strategy which implies estimating the maximum number of smiles for a molecule is computationally not feasible for large molecules, which can reach close to 100'000 different smiles.

A quick workaround is to consider only a subset of ESOL, e.g. only _small_ molecules, i.e. molecule which have at most 25 heavy atoms.

## Todos
  - [x] Consider only a subset of ESOL, called "ESOL_small"
  - [x] Check if the augmentation strategy works

## Status
- [x] Ready to go