### PR TITLE
torch VS numpy world

### DIFF
--- a/maxsmi/pytorch_evaluation.py
+++ b/maxsmi/pytorch_evaluation.py
@@ -36,8 +36,8 @@ def model_evaluation(
 
     Returns
     -------
-    tuple : (torch.tensor, torch.tensor)
-        The predicted, true output values in the data loader.
+    tuple of dict:
+        Dictionary of the predicted, true output values, respectively, in the data loader, with SMILES as keys.
     """
 
     ml_model.eval()
@@ -59,6 +59,10 @@ def model_evaluation(
 
             # Prediction
             output_pred = ml_model(input_true)
+
+            # Convert to numpy arrays
+            output_pred = output_pred.cpu().detach().numpy()
+            output_true = output_true.cpu().detach().numpy()
 
             for smile in smiles:
                 all_output_pred[smile] = output_pred

--- a/maxsmi/tests/test_utils_evaluation.py
+++ b/maxsmi/tests/test_utils_evaluation.py
@@ -6,7 +6,7 @@ Unit and regression test for the maxsmi package.
 # import maxsmi
 import pytest
 import sys
-import torch
+import numpy
 from maxsmi.utils_evaluation import evaluation_results
 
 
@@ -17,12 +17,11 @@ def test_maxsmi_imported():
 
 ####################
 @pytest.mark.parametrize(
-    "pred_output, true_output, cuda_available, solution",
+    "pred_output, true_output, solution",
     [
-        (torch.zeros(2), torch.zeros(2), False, (0, 0, 1)),
-        (torch.zeros(2), torch.zeros(2), True, (0, 0, 1)),
+        (numpy.zeros(2), numpy.zeros(2), (0, 0, 1)),
     ],
 )
-def test_evaluation_results(pred_output, true_output, cuda_available, solution):
-    results = evaluation_results(true_output, pred_output, cuda_available)
+def test_evaluation_results(pred_output, true_output, solution):
+    results = evaluation_results(true_output, pred_output)
     assert solution == results

--- a/maxsmi/utils_evaluation.py
+++ b/maxsmi/utils_evaluation.py
@@ -5,39 +5,31 @@ Evaluation metrics.
 Handles the primary functions
 """
 
-from sklearn.metrics import r2_score
-import torch
-import torch.nn as nn
+from sklearn.metrics import r2_score, mean_squared_error
 
 
-def evaluation_results(output_true, output_predicted, cuda_available):
+def evaluation_results(output_true, output_predicted):
     """
     Computes metrics on ML predictions.
 
     Parameters
     ----------
-    output_true : torch.tensor
+    output_true : array
         Labelled output from the data.
-    output_predicted : torch.tensor
+    output_predicted : array
         Predicted output from the model.
-    cuda_available : bool
-        Is CUDA available.
 
     Returns
     -------
-    tuple
+    tuple of float
         (mean squared error,
         root mean squared error,
         measure of good-of-fit)
     """
-    loss_function = nn.MSELoss()
-    loss_value = loss_function(output_predicted, output_true)
-    root_loss_value = torch.sqrt(loss_value)
-    if cuda_available:
-        r2 = r2_score(
-            output_true.cpu().detach().numpy(), output_predicted.cpu().detach().numpy()
-        )
-    else:
-        r2 = r2_score(output_true.detach().numpy(), output_predicted.detach().numpy())
+    mean_squared_err = mean_squared_error(output_true, output_predicted, squared=True)
+    root_mean_squared_err = mean_squared_error(
+        output_true, output_predicted, squared=False
+    )
+    goodness_of_fit = r2_score(output_true, output_predicted)
 
-    return (loss_value.item(), root_loss_value.item(), r2)
+    return (mean_squared_err, root_mean_squared_err, goodness_of_fit)


### PR DESCRIPTION
## Description
Decide on where to switch from torch tensors to numpy arrays.
As soon as we leave model training, we switch to numpy, using, for a tensor called `my_tensor`:
`my_tensor.cpu().detach().numpy()`

This means that the metrics are computed using not torch functions (such as `nn.MSE`), but scikit-learn functions (e.g. `mean_squared_error`).

### Note
This can be done, because all the heavy computation is done using CUDA when available. The metrics are computed by batch and only two vectors are stored, the true output and the predicted output.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Change workflow where necessary
  - [x] Update ` evaluation_results` and `model_evaluation` functions
  - [x] Update tests 
  - [x] Check if it runs smoothly on the cluster (with and without gpu)


## Status
- [ ] Ready to go